### PR TITLE
Rename isAlive() to is_alive() for threading

### DIFF
--- a/pexecute/thread/runner.py
+++ b/pexecute/thread/runner.py
@@ -18,4 +18,4 @@ class ThreadRunner(RunnerWrapper):
     def is_running(self):
         """ Returns True if runner is active else False """
 
-        return self.runner and self.runner.isAlive()
+        return self.runner and self.runner.is_alive()


### PR DESCRIPTION
Python3.9 removed a deprecated method of threading. Thread object - isAlive(). The new function is is_alive().